### PR TITLE
Fix phpcs warnings and update code style.

### DIFF
--- a/modules/geocoder_address/src/Geocoder/Dumper/AddressText.php
+++ b/modules/geocoder_address/src/Geocoder/Dumper/AddressText.php
@@ -14,7 +14,7 @@ use Geocoder\Model\Address;
  */
 class AddressText implements Dumper {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function dump(Address $address) {
     $values = array();

--- a/modules/geocoder_address/src/Plugin/Geocoder/DataPrepare/Address.php
+++ b/modules/geocoder_address/src/Plugin/Geocoder/DataPrepare/Address.php
@@ -22,7 +22,7 @@ use Drupal\geocoder\Plugin\GeocoderPluginInterface;
  */
 class Address extends DataPrepareBase implements GeocoderPluginInterface {
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function prepareValues(array &$values) {
     foreach ($values as $index => $value) {

--- a/modules/geocoder_address/src/Plugin/Geocoder/Dumper/AddressText.php
+++ b/modules/geocoder_address/src/Plugin/Geocoder/Dumper/AddressText.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class AddressText extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -41,7 +41,7 @@ function geocoder_field_form_field_config_edit_form_alter(array &$form, FormStat
  * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state object.
  */
-function geocoder_field_field_config_edit_form_validate(array $form,  FormStateInterface $form_state) {
+function geocoder_field_field_config_edit_form_validate(array $form, FormStateInterface $form_state) {
   // Clean-up and normalize the plugin list.
   $trail = ['third_party_settings', 'geocoder_field', 'plugins'];
   $plugins = array_keys(array_filter($form_state->getValue($trail),

--- a/modules/geocoder_field/src/GeocoderFieldPluginManager.php
+++ b/modules/geocoder_field/src/GeocoderFieldPluginManager.php
@@ -15,6 +15,9 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\geocoder\Plugin\GeocoderPluginManager;
 use Drupal\geocoder_field\Annotation\GeocoderField;
 
+/**
+ * The Geocoder Field Plugin manager.
+ */
 class GeocoderFieldPluginManager extends DefaultPluginManager {
 
   /**

--- a/modules/geocoder_field/src/Plugin/Geocoder/Field/DefaultField.php
+++ b/modules/geocoder_field/src/Plugin/Geocoder/Field/DefaultField.php
@@ -154,7 +154,7 @@ class DefaultField extends PluginBase implements GeocoderFieldPluginInterface, C
             $this->t('Aggregated into a single MULTIPOINT geofield (e.g. One MULTIPOINT polygon from multiple address fields)'),
             $this->t('Broken up into multiple geometries (e.g. One MULTIPOINT to multiple POINTs.)'),
           ],
-        ]
+        ],
       ],
       '#default_value' => $field->getThirdPartySetting('geocoder_field', 'delta_handling', 'default'),
       '#options' => [
@@ -178,7 +178,7 @@ class DefaultField extends PluginBase implements GeocoderFieldPluginInterface, C
         'preserve' => $this->t('Preserve the existing field value'),
         'empty' => $this->t('Empty the field value'),
       ],
-      '#default_value' => $failure['handling']
+      '#default_value' => $failure['handling'],
     ];
     $element['failure']['status_message'] = [
       '#type' => 'checkbox',
@@ -197,6 +197,6 @@ class DefaultField extends PluginBase implements GeocoderFieldPluginInterface, C
   /**
    * {@inheritdoc}
    */
-  public function validateSettingsForm(array $form, FormStateInterface &$form_state) { }
+  public function validateSettingsForm(array $form, FormStateInterface &$form_state) {}
 
 }

--- a/modules/geocoder_geofield/src/Geocoder/Dumper/Geohash.php
+++ b/modules/geocoder_geofield/src/Geocoder/Dumper/Geohash.php
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Contains \Drupal\geocoder_geofield\Geocoder\Dumper\Geohash.
  */
 
 namespace Drupal\geocoder_geofield\Geocoder\Dumper;
@@ -11,28 +12,34 @@ use Geocoder\Model\Address;
 use Drupal\geophp\geoPHPInterface;
 
 /**
+ * The Geohash geocoder dumper.
+ *
  * @author Pol Dellaiera <pol.dellaiera@gmail.com>
  */
 class Geohash implements Dumper {
   /**
+   * The Geocoder dumper object.
+   *
    * @var \Geocoder\Dumper\Dumper
    */
   protected $dumper;
 
   /**
+   * The Geophp object.
+   *
    * @var \Drupal\geophp\geoPHPInterface
    */
   protected $geophp;
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function dump(Address $address) {
     return $this->geophp->load($this->dumper->dump($address), 'json')->out('geohash');
   }
 
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function __construct(Dumper $dumper, geoPHPInterface $geophp) {
     $this->dumper = $dumper;

--- a/modules/geocoder_geofield/src/Geocoder/Dumper/Geometry.php
+++ b/modules/geocoder_geofield/src/Geocoder/Dumper/Geometry.php
@@ -25,14 +25,14 @@ class Geometry implements Dumper {
   private $geophp;
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function dump(Address $address) {
     return $this->geophp->load($this->dumper->dump($address), 'json');
   }
 
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function __construct(Dumper $dumper, geoPHPInterface $geophp) {
     $this->dumper = $dumper;

--- a/modules/geocoder_geofield/src/Plugin/Geocoder/DataPrepare/Geofield.php
+++ b/modules/geocoder_geofield/src/Plugin/Geocoder/DataPrepare/Geofield.php
@@ -22,14 +22,14 @@ use Drupal\geocoder\Plugin\GeocoderPluginInterface;
  */
 class Geofield extends DataPrepareBase implements GeocoderPluginInterface {
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function prepareValues(array &$values = array()) {
     return parent::prepareValues($values);
   }
 
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function getPreparedReverseGeocodeValues(array $values = array()) {
     return parent::getPreparedReverseGeocodeValues($values);

--- a/modules/geocoder_geofield/src/Plugin/Geocoder/Dumper/Geohash.php
+++ b/modules/geocoder_geofield/src/Plugin/Geocoder/Dumper/Geohash.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Geohash extends GeoJson implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/modules/geocoder_geofield/src/Plugin/Geocoder/Dumper/Geometry.php
+++ b/modules/geocoder_geofield/src/Plugin/Geocoder/Dumper/Geometry.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Geometry extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/modules/geocoder_geofield/tests/modules/geocoder_geofield_test/src/Plugin/Geocoder/Provider/TestProvider.php
+++ b/modules/geocoder_geofield/tests/modules/geocoder_geofield_test/src/Plugin/Geocoder/Provider/TestProvider.php
@@ -42,6 +42,7 @@ class TestProvider extends ProviderBase implements ProviderInterface {
     switch ($data) {
       case 'Gotham City':
         return $this->addressFactory->createFromArray([['latitude' => 20, 'longitude' => 40]]);
+
       default:
         return FALSE;
     }

--- a/modules/geocoder_geofield/tests/src/Kernel/GeocoderGeofieldIntegrationTest.php
+++ b/modules/geocoder_geofield/tests/src/Kernel/GeocoderGeofieldIntegrationTest.php
@@ -25,7 +25,7 @@ class GeocoderGeofieldIntegrationTest extends KernelTestBase {
   public static $modules = ['geophp', 'geofield', 'field', 'geocoder_geofield', 'geocoder_geofield_test', 'geocoder', 'geocoder_field', 'entity_test', 'text', 'user', 'filter'];
 
   /**
-   * Tests the
+   * Tests the geocoding on Geofield field type.
    */
   public function testGeofield() {
     $this->installEntitySchema('entity_test');

--- a/src/Plugin/Geocoder/DataPrepareBase.php
+++ b/src/Plugin/Geocoder/DataPrepareBase.php
@@ -7,7 +7,6 @@
 namespace Drupal\geocoder\Plugin\Geocoder;
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\geocoder\Plugin\GeocoderPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -46,7 +45,7 @@ abstract class DataPrepareBase extends GeocoderPluginBase implements DataPrepare
   }
 
   /**
-   * @inheritDoc
+   * {@inheritdoc}
    */
   public function getEntity() {
     return $this->entity;
@@ -129,7 +128,7 @@ abstract class DataPrepareBase extends GeocoderPluginBase implements DataPrepare
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/DataPrepareInterface.php
+++ b/src/Plugin/Geocoder/DataPrepareInterface.php
@@ -8,7 +8,6 @@ namespace Drupal\geocoder\Plugin\Geocoder;
 
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 
 /**

--- a/src/Plugin/Geocoder/Dumper/GeoJson.php
+++ b/src/Plugin/Geocoder/Dumper/GeoJson.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class GeoJson extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/Dumper/Geometry.php
+++ b/src/Plugin/Geocoder/Dumper/Geometry.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Geometry extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/Dumper/Gpx.php
+++ b/src/Plugin/Geocoder/Dumper/Gpx.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Gpx extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/Dumper/Kml.php
+++ b/src/Plugin/Geocoder/Dumper/Kml.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Kml extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/Dumper/Wkb.php
+++ b/src/Plugin/Geocoder/Dumper/Wkb.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Wkb extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/Dumper/Wkt.php
+++ b/src/Plugin/Geocoder/Dumper/Wkt.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Wkt extends DumperBase implements DumperInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/Geocoder/DumperBase.php
+++ b/src/Plugin/Geocoder/DumperBase.php
@@ -21,7 +21,7 @@ abstract class DumperBase extends GeocoderPluginBase implements DumperInterface 
   private $geocoder_dumper;
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, \Geocoder\Dumper\Dumper $dumper) {
     $this->setGeocoderDumper($dumper);
@@ -29,21 +29,21 @@ abstract class DumperBase extends GeocoderPluginBase implements DumperInterface 
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function dump(Address $address) {
     return $this->getGeocoderDumper()->dump($address);
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function setGeocoderDumper(\Geocoder\Dumper\Dumper $dumper) {
     $this->geocoder_dumper = $dumper;
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function getGeocoderDumper() {
     return $this->geocoder_dumper;

--- a/src/Plugin/Geocoder/Provider/ArcGISOnline.php
+++ b/src/Plugin/Geocoder/Provider/ArcGISOnline.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class ArcGISOnline extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/BingMaps.php
+++ b/src/Plugin/Geocoder/Provider/BingMaps.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class BingMaps extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/File.php
+++ b/src/Plugin/Geocoder/Provider/File.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class File extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Drupal\geocoder\Geocoder\Provider\File());

--- a/src/Plugin/Geocoder/Provider/FreeGeoIp.php
+++ b/src/Plugin/Geocoder/Provider/FreeGeoIp.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class FreeGeoIp extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\FreeGeoIp($this->getAdapter()));

--- a/src/Plugin/Geocoder/Provider/GeoPlugin.php
+++ b/src/Plugin/Geocoder/Provider/GeoPlugin.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class GeoPlugin extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\GeoPlugin($this->getAdapter()));

--- a/src/Plugin/Geocoder/Provider/Geoip.php
+++ b/src/Plugin/Geocoder/Provider/Geoip.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class Geoip extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\Geoip());

--- a/src/Plugin/Geocoder/Provider/Geonames.php
+++ b/src/Plugin/Geocoder/Provider/Geonames.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class Geonames extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/GoogleMaps.php
+++ b/src/Plugin/Geocoder/Provider/GoogleMaps.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class GoogleMaps extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\GoogleMaps($this->getAdapter()));

--- a/src/Plugin/Geocoder/Provider/HostIp.php
+++ b/src/Plugin/Geocoder/Provider/HostIp.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class HostIp extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\HostIp($this->getAdapter()));

--- a/src/Plugin/Geocoder/Provider/IpInfoDb.php
+++ b/src/Plugin/Geocoder/Provider/IpInfoDb.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class IpInfoDb extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/MapQuest.php
+++ b/src/Plugin/Geocoder/Provider/MapQuest.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class MapQuest extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/MaxMind.php
+++ b/src/Plugin/Geocoder/Provider/MaxMind.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class MaxMind extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/Nominatim.php
+++ b/src/Plugin/Geocoder/Provider/Nominatim.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class Nominatim extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/OpenCage.php
+++ b/src/Plugin/Geocoder/Provider/OpenCage.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class OpenCage extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/OpenStreetMap.php
+++ b/src/Plugin/Geocoder/Provider/OpenStreetMap.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class OpenStreetMap extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\OpenStreetMap($this->getAdapter()));

--- a/src/Plugin/Geocoder/Provider/TomTom.php
+++ b/src/Plugin/Geocoder/Provider/TomTom.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class TomTom extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $configuration = $this->getConfiguration();

--- a/src/Plugin/Geocoder/Provider/Yandex.php
+++ b/src/Plugin/Geocoder/Provider/Yandex.php
@@ -19,7 +19,7 @@ use Drupal\geocoder\Plugin\Geocoder\ProviderInterface;
  */
 class Yandex extends ProviderBase implements ProviderInterface {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function init() {
     $this->setHandler(new \Geocoder\Provider\Yandex($this->getAdapter()));

--- a/src/Plugin/GeocoderPluginBase.php
+++ b/src/Plugin/GeocoderPluginBase.php
@@ -34,7 +34,7 @@ abstract class GeocoderPluginBase extends PluginBase implements GeocoderPluginIn
   }
 
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(

--- a/src/Plugin/GeocoderPluginManager.php
+++ b/src/Plugin/GeocoderPluginManager.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\Container;
  */
 class GeocoderPluginManager extends DefaultPluginManager {
   /**
-   * @inheritdoc
+   * {@inheritdoc}
    */
   public function __construct($type, \Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     $plugin_definition_annotation_name = 'Drupal\geocoder\Annotation\GeocoderPlugin';


### PR DESCRIPTION
Replace @inheritdoc with {@inheritdoc}
Fix all the PHPCS warnings and errors by running phpcbf on the whole project.
Add some missing descriptions and methods headers.
